### PR TITLE
Resolve build failure when building xcode-to-cmake

### DIFF
--- a/mulle-xcode-settings.rb
+++ b/mulle-xcode-settings.rb
@@ -9,7 +9,7 @@ depends_on "mulle-build" => :build
 depends_on "mulle-bootstrap" => :build
 
 def install
-  system "xcodebuild", "-configuration", "Release", "DSTROOT=#{prefix}", "install"
+  system "xcodebuild", "-UseModernBuildSystem=NO", "-configuration", "Release", "DSTROOT=#{prefix}", "install"
 end
 end
 # FORMULA mulle-xcode-settings.rb


### PR DESCRIPTION
**Build error before patch:**

```
==> xcodebuild DSTROOT=/usr/local/Cellar/mulle-xcode-to-cmake/0.9.0 INSTALL_PATH=/bin i
Last 15 lines from /Users/localhost/Library/Logs/Homebrew/mulle-xcode-to-cmake/01.xcodebuild:
DSTROOT=/usr/local/Cellar/mulle-xcode-to-cmake/0.9.0
INSTALL_PATH=/bin
install

Build settings from command line:
    DSTROOT = /usr/local/Cellar/mulle-xcode-to-cmake/0.9.0
    INSTALL_PATH = /bin

2021-07-06 12:03:03.924 XCBBuildService[98849:2033108] /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk: error: SDK 'macosx10.14' already registered from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.6.sdk
2021-07-06 12:03:04.163 XCBBuildService[98849:2033108] /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk: error: SDK 'macosx10.14' already registered from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.6.sdk
note: Using new build system
error: unknown error while handling message: unableToInitializeCore(errors: ["/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk: error: SDK \'macosx10.14\' already registered from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.6.sdk"])

** INSTALL FAILED **


If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/mulle-kybernetik/homebrew-software/issues
```